### PR TITLE
Improve the Firebase Account Module

### DIFF
--- a/Sources/CardinalKitFirebaseAccount/FirebaseAccountError.swift
+++ b/Sources/CardinalKitFirebaseAccount/FirebaseAccountError.swift
@@ -21,15 +21,15 @@ enum FirebaseAccountError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .invalidEmail:
-            return ""
+            return "FIREBASE_ACCOUNT_ERROR_INVALID_EMAIL"
         case .accountAlreadyInUse:
-            return ""
+            return "FIREBASE_ACCOUNT_ALREADY_IN_USE"
         case .weakPassword:
-            return ""
+            return "FIREBASE_ACCOUNT_WEAK_PASSWORD"
         case .setupError:
-            return ""
+            return "FIREBASE_ACCOUNT_SETUP_ERROR"
         case .unknown:
-            return ""
+            return "FIREBASE_ACCOUNT_UNKNOWN"
         }
     }
     
@@ -40,15 +40,15 @@ enum FirebaseAccountError: LocalizedError {
     var recoverySuggestion: String? {
         switch self {
         case .invalidEmail:
-            return ""
+            return "FIREBASE_ACCOUNT_ERROR_INVALID_EMAIL_SUGGESTION"
         case .accountAlreadyInUse:
-            return ""
+            return "FIREBASE_ACCOUNT_ALREADY_IN_USE_SUGGESTION"
         case .weakPassword:
-            return ""
+            return "FIREBASE_ACCOUNT_WEAK_PASSWORD_SUGGESTION"
         case .setupError:
-            return ""
+            return "FIREBASE_ACCOUNT_SETUP_ERROR_SUGGESTION"
         case .unknown:
-            return ""
+            return "FIREBASE_ACCOUNT_UNKNOWN_SUGGESTION"
         }
     }
     

--- a/Sources/CardinalKitFirebaseAccount/Resources/de.lproj/Localizable.strings
+++ b/Sources/CardinalKitFirebaseAccount/Resources/de.lproj/Localizable.strings
@@ -1,0 +1,25 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+// MARK: ERRORS
+"FIREBASE_ACCOUNT_DEFAULT_PASSWORD_RULE_ERROR" = "Ein Password muss mindestens acht Zeichen und keine Leerzeichen haben.";
+
+"FIREBASE_ACCOUNT_ERROR_INVALID_EMAIL" = "Inkorrekte E-Mail Adresse";
+"FIREBASE_ACCOUNT_ERROR_INVALID_EMAIL_SUGGESTION" = "Bitte geben Sie eine korrekte E-Mail Adressse ein.";
+
+"FIREBASE_ACCOUNT_ALREADY_IN_USE" = "Benutzerkonto existiert bereits";
+"FIREBASE_ACCOUNT_ALREADY_IN_USE_SUGGESTION" = "Ein Benutzerkonto mit dieser E-Mail Adresse existiert bereits. Bitte loggen Sie sich mit dem Account ein.";
+
+"FIREBASE_ACCOUNT_WEAK_PASSWORD" = "Schwaches Passwort";
+"FIREBASE_ACCOUNT_WEAK_PASSWORD_SUGGESTION" = "Bitte geben Sie ein stärkeres Password ein.";
+
+"FIREBASE_ACCOUNT_SETUP_ERROR" = "Benutzerkonto konnte nicht erstelle werden";
+"FIREBASE_ACCOUNT_SETUP_ERROR_SUGGESTION" = "Bitte überprüfen Sie Ihre E-Mail Adresse und versichen Sie es erneut";
+
+"FIREBASE_ACCOUNT_UNKNOWN" = "Benutzerkonto konnte nicht erstelle werden";
+"FIREBASE_ACCOUNT_UNKNOWN_SUGGESTION" = "Bitte überprüfen Sie Ihre E-Mail Adresse und versichen Sie es erneut";

--- a/Sources/CardinalKitFirebaseAccount/Resources/en.lproj/Localizable.strings
+++ b/Sources/CardinalKitFirebaseAccount/Resources/en.lproj/Localizable.strings
@@ -1,0 +1,26 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+// MARK: ERRORS
+"FIREBASE_ACCOUNT_DEFAULT_PASSWORD_RULE_ERROR" = "A password has to have at least eight characters and no whitespaces.";
+
+"FIREBASE_ACCOUNT_ERROR_INVALID_EMAIL" = "Invalid email address";
+"FIREBASE_ACCOUNT_ERROR_INVALID_EMAIL_SUGGESTION" = "Please enter a valid email address.";
+
+"FIREBASE_ACCOUNT_ALREADY_IN_USE" = "Account already exists";
+"FIREBASE_ACCOUNT_ALREADY_IN_USE_SUGGESTION" = "An account with this email already exists. Please login using your email and password.";
+
+"FIREBASE_ACCOUNT_WEAK_PASSWORD" = "Weak Password";
+"FIREBASE_ACCOUNT_WEAK_PASSWORD_SUGGESTION" = "Please choose a safer password.";
+
+"FIREBASE_ACCOUNT_SETUP_ERROR" = "Could not create the user account.";
+"FIREBASE_ACCOUNT_SETUP_ERROR_SUGGESTION" = "Please check your internet connection and try again.";
+
+"FIREBASE_ACCOUNT_UNKNOWN" = "Could not create the user account.";
+"FIREBASE_ACCOUNT_UNKNOWN_SUGGESTION" = "Please check your internet connection and try again.";


### PR DESCRIPTION
# Improve the Firebase Account Module

## :recycle: Current situation & Problem
- Firebase includes some built-in password rules that we do not expose in the API
- We do not display localized error messages for Firebase errors
- The localization of the sign-up button is not correctly set
- The application does not recognize if, e.g., a user is deleted in the Firebase Emulator or on Firebase
- The application does not refresh its state when the user is logged in

Thank you to @jenlmoore for providing valuable feedback to the CardinalKit project!

## :bulb: Proposed solution
- Includes a password rule in the UI (at least eight characters, no whitespaces)
- Adds localized descriptions for Firebase Errors
- Improves the logic in the account module to use the correct localization
- Automatically sets the user to nil and the account to be signed out if a user refresh token request did not succeed
- Adds further logic to refresh the application if a user is signed in

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).